### PR TITLE
Resolution of strings to classes for subscribers

### DIFF
--- a/lib/entity_store.rb
+++ b/lib/entity_store.rb
@@ -1,5 +1,6 @@
 module EntityStore
 
+  require_relative 'entity_store/utils'
   require_relative 'entity_store/logging'
   require_relative 'entity_store/config'
   require_relative 'entity_store/time_factory'

--- a/lib/entity_store/event_bus.rb
+++ b/lib/entity_store/event_bus.rb
@@ -27,7 +27,14 @@ module EntityStore
     end
 
     def subscribers
-      EntityStore::Config.event_subscribers
+      EntityStore::Config.event_subscribers.map do |subscriber|
+        case subscriber
+        when String
+          Utils.get_type_constant(subscriber)
+        else
+          subscriber
+        end
+      end
     end
 
     def publish_to_feed(entity_type, event)

--- a/lib/entity_store/utils.rb
+++ b/lib/entity_store/utils.rb
@@ -1,0 +1,8 @@
+module EntityStore
+  module Utils
+    def self.get_type_constant(type_name)
+      type_name.split('::').inject(Object) { |obj, name| obj.const_get(name) }
+    end
+  end
+end
+


### PR DESCRIPTION
Enables subscribers to be specified as strings so that they are resolved on each call and therefore can be compatible with autoloading.
