### PR TITLE
Cleanse attributes before saving to Mongo

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    entity_store (0.2.12)
+    entity_store (0.2.13)
       bson_ext (~> 1.8)
       hatchet (~> 0.2)
       mongo (~> 1.8)

--- a/spec/entity_store/mongo_entity_store_spec.rb
+++ b/spec/entity_store/mongo_entity_store_spec.rb
@@ -4,7 +4,7 @@ module MongoEntityStoreSpec
   class DummyEntity
     include EntityStore::Entity
 
-    attr_accessor :name, :description
+    attr_accessor :by, :name, :description
 
   end
 end
@@ -92,8 +92,10 @@ describe MongoEntityStore do
       saved_entity = @store.entities.find_one({'_id' => BSON::ObjectId.from_string(@entity.id)})['snapshot']
       saved_entity['id'].should eq(@entity.id)
       saved_entity['version'].should eq(@entity.version)
+      saved_entity['by'].should be_nil
       saved_entity['name'].should eq(@entity.name)
       saved_entity['description'].should eq(@entity.description)
+      saved_entity.keys.should_not include 'by'
     end
   end
 end


### PR DESCRIPTION
As Mongo documents return nil when an unknown key is requested, there is no need to explicitly store them, incurring the overhead of an additional key in the document.
