### PR TITLE
Alias attributes as to_hash and to_h

### DIFF
--- a/lib/entity_store/hash_serialization.rb
+++ b/lib/entity_store/hash_serialization.rb
@@ -24,6 +24,9 @@ module EntityStore
       attrs
     end
 
+    alias_method :to_hash, :attributes
+    alias_method :to_h, :attributes
+
     def attribute_methods
       public_methods
         .select { |m| m =~ /\w\=$/ }


### PR DESCRIPTION
I came across an instance where I'd moved from `OpenStruct` that defines a [`#to_h`](http://www.ruby-doc.org/stdlib-2.0/libdoc/ostruct/rdoc/OpenStruct.html#method-i-to_h) to a class using the `EntityValue` mixin. This led to an error as no `#to_h` method was defined on the `EntityValue`.

I think that the `#attributes` method is semantically identical to the purpose of `#to_h` (and the long-hand `#to_hash`) so I think it's worth aliasing them as a "sensible default". People can always override the implementations if they wish.

What do you think @adambird?
