### PR TITLE
Reassign array attributes on set

### DIFF
--- a/lib/entity_store/attributes.rb
+++ b/lib/entity_store/attributes.rb
@@ -26,21 +26,25 @@ module EntityStore
       end
 
       def entity_value_array_attribute name, klass
-        define_method(name) {
-          instance_variable_get("@_#{name}") || instance_variable_set("@_#{name}", [])
-        }
+        variable_name = "@_#{name}".to_sym
 
-        define_method("#{name}=") do |value|
-          value.each do |item|
-            case item
+        define_method(name) do
+          instance_variable_get(variable_name) || instance_variable_set(variable_name, [])
+        end
+
+        define_method("#{name}=") do |values|
+          mapped_values = values.map do |value|
+            case value
             when Hash
-              send(name) << klass.new(item)
+              klass.new(value)
             when klass
-              send(name) << item
+              value
             else
-              raise ArgumentError.new("#{item.class.name} not supported. Expecting #{klass.name}")
+              raise ArgumentError.new("#{value.class} not supported. Expecting #{klass.name}")
             end
           end
+
+          instance_variable_set(variable_name, mapped_values)
         end
       end
 

--- a/spec/entity_store/entity_spec.rb
+++ b/spec/entity_store/entity_spec.rb
@@ -131,6 +131,18 @@ describe Entity do
           expect { entity.things = items }.to raise_error(ArgumentError)
         end
       end
+      context "when already populated" do
+        let(:items) { [ ThingEntityValue.new(name: random_string), ThingEntityValue.new(name: random_string)] }
+
+        before(:each) do
+          entity.things = [{ name: random_string }, { name: random_string }]
+          entity.things = items
+        end
+
+        it "should replace the contents" do
+          entity.things.should eq(items)
+        end
+      end
     end
 
     describe "getter" do


### PR DESCRIPTION
Previously, the array was being appended to by set operations. This changes the implementation to reassign the property like a standard attr_accessor would.
