### PR TITLE
Take snapshot before publishing events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    entity_store (0.3.5)
+    entity_store (0.3.6)
       bson_ext (~> 1.8)
       hatchet (~> 0.2)
       mongo (~> 1.8)

--- a/lib/entity_store/store.rb
+++ b/lib/entity_store/store.rb
@@ -28,8 +28,10 @@ module EntityStore
         else
           entity.id = storage_client.add_entity(entity)
         end
-        add_events(entity)
-        snapshot_entity(entity) if entity.version % Config.snapshot_threshold == 0
+
+        add_events(entity) do
+          snapshot_entity(entity) if entity.version % Config.snapshot_threshold == 0
+        end
 
         # publish version increment signal event to the bus
         event_bus.publish(entity.type, entity.generate_version_incremented_event)
@@ -60,6 +62,8 @@ module EntityStore
         event
       end
       storage_client.add_events(items)
+
+      yield if block_given?
 
       items.each {|e| event_bus.publish(entity.type, e) }
 

--- a/spec/entity_store/store_spec.rb
+++ b/spec/entity_store/store_spec.rb
@@ -82,7 +82,7 @@ describe Store do
       @entity.version = random_integer * EntityStore::Config.snapshot_threshold
       @storage_client = double("StorageClient", :save_entity => true)
       @store = Store.new
-      @store.stub(:add_events)
+      @store.stub(:add_events).and_yield
       @store.stub(:storage_client) { @storage_client }
       @entity.stub(:pending_events) { [ double('Event') ] }
     end


### PR DESCRIPTION
I hit a scenario whereby if an event was listened for that also updated the entity, the snapshot would become incorrect.

This seemed to be the lowest impact way of implementing the desired behaviour as the public API wasn't changed.
#### Bug description

Examples assume a snapshot threshold of 1.

The previous behaviour:

```
+- Publish FooSet event sets foo=1
|
+-+- foo_set listener which results in something that sets foo=2
  |
  +- Save snapshot with foo=2
  |
+-+- exit listener
|
+- Save snapshot with foo=1
|
+- Snapshot is now incorrect
```

By taking the snapshot before publishing the event:

```
+- Publish FooSet event sets foo=1
|
+- Save snapshot with foo=1
|
+-+- foo_set listener which results in something that sets foo=2
  |
  +- Save snapshot with foo=2
  |
+-+- exit listener
|
+- Snapshot is now correct
```
