### PR TITLE
Formatted backtrace in error log

### DIFF
--- a/lib/entity_store/logging.rb
+++ b/lib/entity_store/logging.rb
@@ -10,7 +10,7 @@ module EntityStore
     def log_error(message, exception)
       if Config.logger
         Config.logger.error message
-        Config.logger.error exception.backtrace
+        Config.logger.error exception.backtrace.join("\n\t")
       end
     end
   end


### PR DESCRIPTION
It previously passed the raw array to the logger which when used with `to_s` was not readable. It now formats it with newlines and tabs between each line of the backtrace to make it possible to scan it.
