### PR TITLE
Reparative snapshotting

### DIFF
--- a/lib/entity_store/entity.rb
+++ b/lib/entity_store/entity.rb
@@ -32,7 +32,16 @@ module EntityStore
     end
 
     def version=(value)
+      @_snapshot_version = value unless @_snapshot_version
       @_version = value
+    end
+
+    def snapshot_due?
+      if version % Config.snapshot_threshold == 0
+        true
+      else
+        @_snapshot_version and (version - @_snapshot_version) >= Config.snapshot_threshold
+      end
     end
 
     def generate_version_incremented_event


### PR DESCRIPTION
As snapshots can be invalidated we can end up with entities that have hundreds of events and no snapshot. The previous implementation relied on the modulus of the version and the snapshot threshold being checked.

This meant that for a snapshot threshold of 10 and an existing entity on version 251 in the event of the snapshot being invalidated for whatever reason, we would replay all of the events every time we interact with the entity until it reached version 260.

This change now also checks the difference between the first version set and the current version in order to determine whether the entity should be snapshotted so the snapshots will be aggressively taken in a manner similar to how they are discarded.

It also moves the logic of whether a snapshot should be taken to a method on the entity to allow clients of the gem to override the behaviour however they deem necessary.