### PR TITLE
Invert call made to apply an event to an Entity

### DIFF
--- a/lib/entity_store/store.rb
+++ b/lib/entity_store/store.rb
@@ -113,7 +113,7 @@ module EntityStore
 
         entity_events.each do |event|
           begin
-            event.apply(entity)
+            entity.apply_event(event)
             log_debug { "Applied #{event.inspect} to #{id}" }
           rescue => e
             log_error "Failed to apply #{event.class.name} #{event.attributes} to #{id} with #{e.inspect}", e
@@ -162,7 +162,7 @@ module EntityStore
         storage_client.get_events(id, entity.version).each do |event|
 
           begin
-            event.apply(entity)
+            entity.apply_event(event)
             entity.version = event.entity_version
 
             render = true


### PR DESCRIPTION
By calling `Entity#apply_event(event)` rather than `Event#apply(entity)` we expose the option for this behaviour to be extended downstream more easily.

In order to wrap every event application, developers will now be able to override the `Entity#apply_event(event)` method for cross-cutting hooks as well as being able to define `Event#apply(entity)` for specific cases.