### PR TITLE
Allow entity store to be initialized

### DIFF
--- a/lib/entity_store/store.rb
+++ b/lib/entity_store/store.rb
@@ -2,8 +2,17 @@ module EntityStore
   class Store
     include Logging
 
+    def initialize(storage_client = nil, event_bus = nil)
+      @_storage_client = storage_client if storage_client
+      @_event_bus = event_bus if event_bus
+    end
+
     def storage_client
       @_storage_client ||= EntityStore::Config.store
+    end
+
+    def event_bus
+      @_event_bus ||= EventBus.new
     end
 
     def add(entity)
@@ -71,7 +80,7 @@ module EntityStore
 
       yield if block_given?
 
-      items.each {|e| event_bus.publish(entity.type, e) }
+      items.each { |e| event_bus.publish(entity.type, e) }
 
       entity.clear_pending_events
     end
@@ -144,10 +153,6 @@ module EntityStore
       end
       storage_client.clear
       @_storage_client = nil
-    end
-
-    def event_bus
-      @_event_bus ||= EventBus.new
     end
 
     # Public: returns an array representing a full audit trail for the entity.

--- a/spec/entity_store_spec.rb
+++ b/spec/entity_store_spec.rb
@@ -26,7 +26,17 @@ class DummyEntitySubscriber
   end
 
   def dummy_entity_name_set(event)
-    DummyEntitySubscriber.event_name = event.name
+    self.class.event_name = event.name
+  end
+end
+
+class AnotherEntitySubscriber
+  class << self
+    attr_accessor :event_name
+  end
+
+  def dummy_entity_name_set(event)
+    self.class.event_name = event.name
   end
 end
 
@@ -78,6 +88,49 @@ class DummyStore
   def save_entity(entity)
     entities[entity.id] = entity
   end
+end
+
+describe "creation without static instances" do
+  let(:store) do
+    storage_client = DummyStore.new
+    Store.new(storage_client, event_bus)
+  end
+
+  let(:event_bus) do
+    event_subscribers = []
+    event_subscribers << AnotherEntitySubscriber
+
+    EventBus.new(event_subscribers)
+  end
+
+  before do
+    EntityStore::Config.setup do |config|
+      config.store = DummyStore.new
+      config.event_subscribers << DummyEntitySubscriber
+    end
+  end
+
+  context "when save entity" do
+    let(:name) { random_string }
+    before(:each) do
+      @entity = DummyEntity.new
+      @entity.set_name name
+      @id = store.save @entity
+    end
+
+    it "does not publish event to the non configured subscriber" do
+      DummyEntitySubscriber.event_name.should_not eq(name)
+    end
+    it "publishes event to the subscriber" do
+      AnotherEntitySubscriber.event_name.should eq(name)
+    end
+    it "is retrievable with the events applied" do
+      store.get(@entity.id).name.should eq(name)
+    end
+    it "is not retrievable from the static store instance" do
+      EntityStore::Store.new.get(@entity.id).should eq(nil)
+    end
+ end
 end
 
 describe "end to end" do


### PR DESCRIPTION
The current implementation relies on static configuration which prevents
two instances of entity store from running.