### PR TITLE
Snapshot when several events added in one version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    entity_store (1.4.0)
+    entity_store (1.5.0)
       bson (~> 4.0)
       hatchet (~> 0.2)
 

--- a/lib/entity_store/version.rb
+++ b/lib/entity_store/version.rb
@@ -1,3 +1,3 @@
 module EntityStore
-  VERSION = "1.4.0".freeze
+  VERSION = "1.5.0".freeze
 end

--- a/spec/entity_store/entity_spec.rb
+++ b/spec/entity_store/entity_spec.rb
@@ -84,7 +84,7 @@ describe Entity do
       subject { DummyEntity.new(1) }
 
       it "should raise a readable error" do
-        expect { subject }.to raise_error(RuntimeError, "Do not know how to create DummyEntity from Fixnum")
+        expect { subject }.to raise_error(RuntimeError, /\ADo not know how to create DummyEntity from (Integer|Fixnum)\z/)
       end
     end
   end


### PR DESCRIPTION
Makes the store aware of how many entity events have been stored upon save and proactively takes a snapshot if the current version involved a number of entity events matching or exceeding the configured snapshot threshold.